### PR TITLE
Remove useless argument in Leaderboards_getCodinGamerClashRanking constructor

### DIFF
--- a/cg_api.php
+++ b/cg_api.php
@@ -829,7 +829,7 @@ class Leaderboards_getCodinGamerClashRanking extends CodinGameApi
 
     const ServiceURL = "Leaderboards/getCodinGamerClashRanking";
 
-    public function __construct(string $_challengePublicId = parent::DefaultChallengePublicId, string $_userId = MySelf::UserId)
+    public function __construct(string $_userId = MySelf::UserId)
     {
         $this->serviceURL = parent::BaseURL . self::ServiceURL;
         $this->userId = $_userId;


### PR DESCRIPTION
I was reading the source code and found that there was this useless argument in the Leaderboards_getCodinGamerClashRanking class constructor. By the way, thank you for making this project, it helps me a lot with my [`codingame` module in python](https://github.com/takos22/codingame).